### PR TITLE
package: add a "repository" section 

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,4 +3,5 @@
   , "version": "0.1.0"
   , "main": "./superagent-oauth"
   , "description": "Tiny superagent plugin to easily sign requests with node-oauth."
+  , "repository": { "type": "git", "url": "git://github.com/LearnBoost/superagent-oauth.git" }
 }


### PR DESCRIPTION
So that `npm docs superagent-oauth` works properly.
