### PR TITLE
use the OAuth2 object's "_accessTokenName" field to get the proper "access_token" query param name

### DIFF
--- a/superagent-oauth.js
+++ b/superagent-oauth.js
@@ -25,7 +25,6 @@ module.exports = function (superagent) {
     this.oa = oa;
     this.token = token;
     this.secret = secret;
-    this.oaAccessField = opts.accessField || 'oauth_token';
     this.oaExtraParams = opts.extraParams || {}
     return this;
   };
@@ -62,7 +61,7 @@ module.exports = function (superagent) {
 
   Request.prototype.signOAuth2 = function () {
     var query = {};
-    query[this.oaAccessField] = this.token;
+    query[this.oa._accessTokenName] = this.token;
     this.query(query);
   };
 


### PR DESCRIPTION
`node-oauth` provides this for us. Also the previous default value of "oauth_token" doesn't work for Facebook as it uses "access_token" as the name (which is the default that node-oauth uses).
